### PR TITLE
Add color scheme preference via GSettings

### DIFF
--- a/data/share/glib-2.0/schemas/dev.boxi.gschema.xml
+++ b/data/share/glib-2.0/schemas/dev.boxi.gschema.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schemalist>
+  <schema id="dev.boxi.Boxi" path="/dev/boxi/Boxi/">
+    <key name="color-scheme" type="s">
+      <default>'default'</default>
+      <choices>
+        <choice value='default'/>
+        <choice value='force-light'/>
+        <choice value='prefer-light'/>
+        <choice value='prefer-dark'/>
+        <choice value='force-dark'/>
+      </choices>
+    </key>
+  </schema>
+</schemalist>

--- a/dev.boxi.Boxi.yml
+++ b/dev.boxi.Boxi.yml
@@ -31,6 +31,7 @@ modules:
     buildsystem: simple
     build-commands:
       - pip3 install --no-build-isolation --prefix=/app .
+      - glib-compile-schemas /app/share/glib-2.0/schemas
 
 command: boxi
 

--- a/dev.boxi.Boxi.yml
+++ b/dev.boxi.Boxi.yml
@@ -9,7 +9,7 @@ modules:
   - name: vte
     sources:
       - type: git
-        url: https://gitlab.gnome.org/GNOME/vte
+        url: https://gitlab.gnome.org/GNOME/vte.git/
         tag: 0.68.0
         commit: 0f438924f9f8a858b1b82434c876e31c2de180d4
     buildsystem: meson

--- a/src/boxi/app.py
+++ b/src/boxi/app.py
@@ -282,7 +282,8 @@ class Application(Gtk.Application):
     def do_startup(self):
         Gtk.Application.do_startup(self)
 
-        Handy.StyleManager.get_default().set_color_scheme(Handy.ColorScheme.PREFER_LIGHT)
+        settings = Gio.Settings('dev.boxi.Boxi')
+        settings.bind('color-scheme', Handy.StyleManager.get_default(), 'color-scheme', Gio.SettingsBindFlags.GET)
 
         self.set_accels_for_action("win.new-window", ["<Ctrl><Shift>N"])
         self.set_accels_for_action("win.edit-contents", ["<Ctrl><Shift>S"])


### PR DESCRIPTION
Add a GSettings schema with a "color-scheme" setting which allows controlling the color scheme preference of our style manager.
    
There's no UI, but you can do something like

```sh
cat > ~/.var/app/dev.boxi.Boxi/config/glib-2.0/settings/keyfile <<EOF
[dev/boxi/Boxi]
color-scheme='prefer-dark'
EOF
```

Fixes #5
