### PR TITLE
flatpak: build VTE from the 0.70.1 release

### DIFF
--- a/dev.boxi.Boxi.yml
+++ b/dev.boxi.Boxi.yml
@@ -8,9 +8,9 @@ sdk: org.gnome.Sdk
 modules:
   - name: vte
     sources:
-      - type: git
-        url: https://gitlab.gnome.org/GNOME/vte.git/
-        commit: 5bf476f1d7283bc805ac8ae6abe94f81ffd7be05
+      - type: archive
+        url: https://download.gnome.org/sources/vte/0.70/vte-0.70.1.tar.xz
+        sha256: 1f4601cbfea5302b96902208c8f185e5b18b259b5358bc93cf392bf59871c5b6
     buildsystem: meson
     config-opts:
       - -Dgtk3=false


### PR DESCRIPTION
Switch over to downloading and installing the archive, instead of a random git tag.