### PR TITLE
Fix appdata and flatpak related issues

### DIFF
--- a/data/share/metainfo/dev.boxi.Boxi.metainfo.xml
+++ b/data/share/metainfo/dev.boxi.Boxi.metainfo.xml
@@ -63,14 +63,17 @@
     <binary>cockpit-client</binary>
   </provides>
 
-  <requires>
+  <recommends>
     <control>keyboard</control>
     <control>pointing</control>
-    <display_length compare="ge">medium</display_length>
-  </requires>
+    <display_length compare="ge">320</display_length>
+  </recommends>
 
-  <content_rating type="oars-1.0"/>
+  <content_rating type="oars-1.1"/>
+
+  <developer_name>Allison Karlitskaya</developer_name>
 
   <url type="homepage">https://boxi.dev/</url>
   <url type="bugtracker">https://github.com/allisonkarlitskaya/boxi/issues</url>
+  <url type="vcs-browser">https://github.com/allisonkarlitskaya/boxi</url>
 </component>

--- a/dev.boxi.Boxi.yml
+++ b/dev.boxi.Boxi.yml
@@ -2,7 +2,7 @@
 
 app-id: dev.boxi.Boxi
 runtime: org.gnome.Platform
-runtime-version: '43'
+runtime-version: '47'
 sdk: org.gnome.Sdk
 
 modules:
@@ -32,7 +32,6 @@ cleanup:
   - '/bin/vte-2.91-gtk4'
   - '/etc'
   - '/include'
-  - '/lib/debug'
   - '/lib/libvte-2.91-gtk4.so'
   - '/lib/pkgconfig'
   - '/lib/python*/site-packages/*.dist-info'
@@ -46,5 +45,7 @@ cleanup:
 
 finish-args:
   - --talk-name=org.freedesktop.Flatpak
+  - --share=ipc
   - --socket=wayland
+  - --socket=fallback-x11
   - --device=dri


### PR DESCRIPTION
### fix appdata papercuts

- Use recommends instead of require
- Fix named display length error
- Add vcs-browser URL to show the source code repository

### fix flatpak related issues

- Use GNOME runtime 47
- fix: toplevel-cleanup-debug
- fix: finish-args-only-wayland
- fix: finish-args-x11-without-ipc